### PR TITLE
fix: build & and deploy container in one step

### DIFF
--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -63,4 +63,4 @@
         key_file: /root/.ssh/deploy_key
 
     - name: Start EuroPythonBot
-      shell: "cd /root/discord && docker compose up -d --build"
+      shell: "cd /root/discord && docker compose up --detach --build"


### PR DESCRIPTION
Hey @Kislovskiy, the debugging was correct. If we were building & running `docker compose up`  the container would be restarted but running just `up` alone doesn't trigger a rebuild. Added the correct flag - https://stackoverflow.com/a/39501539 - that does this in a single step.

Confirmed by triggering playbook w/o manual intervention