### PR TITLE
Add privileged intents to the bot

### DIFF
--- a/EuroPythonBot/bot.py
+++ b/EuroPythonBot/bot.py
@@ -17,13 +17,24 @@ DISCORD_BOT_TOKEN = os.getenv("DISCORD_BOT_TOKEN")
 
 class Bot(commands.Bot):
     def __init__(self):
-        intents = discord.Intents.default()
+        intents = _get_intents()
         super().__init__(command_prefix=commands.when_mentioned_or("$"), intents=intents)
         self.guild = None
         self.channels = dict()
 
     async def on_ready(self):
         print(f"{datetime.now()} INFO: Loggedin as {self.user} (ID: {self.user.id})")
+
+
+def _get_intents() -> discord.Intents:
+    """Get the desired intents for the bot."""
+    intents = discord.Intents.all()
+    intents.presences = False
+    intents.dm_typing = False
+    intents.dm_reactions = False
+    intents.invites = False
+    intents.integrations = False
+    return intents
 
 
 async def main():


### PR DESCRIPTION
These intents would allow us to react to prefixed commands. The prefix is currently configured as `$`.

In addition, it also allows us to listen to members joining the guild, although this is not strictly necessary. Still, if we want to add logging of users joining the guild at some point, to know who makes it "into" the community, this might prove useful.

You do need to enable these intents in your Development bot via the Discord Developer Portal:

- Go to https://discord.com/developers/applications/
- Click on your bot application
- Navigate to "Bot" in the left sidebar
- Toggle the two highlighted switches in this screenshot:

(Note, this has already been done for the production bot, "EuroPython 2023")

![image](https://github.com/EuroPython/discord/assets/33516116/a5752170-426b-48a4-971b-33a82739fb75)


