### PR TITLE
Revert "await all the roles are added"

### DIFF
--- a/EuroPythonBot/cogs/registration.py
+++ b/EuroPythonBot/cogs/registration.py
@@ -1,4 +1,3 @@
-import asyncio
 import logging
 
 from configuration import Config
@@ -54,13 +53,6 @@ class RegistrationForm(discord.ui.Modal, title="Europython 2023 Registration"):
         default="My Full Name",
     )
 
-    async def add_roles(self, interaction, roles):
-        for role in roles:
-            role = discord.utils.get(interaction.guild.roles, id=role)
-            await interaction.user.add_roles(role)
-        while not set(roles).issubset(set([role.id for role in interaction.user.roles])):
-            asyncio.sleep(0.1)
-
     async def on_submit(self, interaction: discord.Interaction) -> None:
         """Assign the role to the user and send a confirmation message."""
 
@@ -69,7 +61,9 @@ class RegistrationForm(discord.ui.Modal, title="Europython 2023 Registration"):
             order=self.order.value,
         )
         _logger.info("Assigning %r roles=%r", self.name.value, roles)
-        await self.add_roles(interaction, roles)
+        for role in roles:
+            role = discord.utils.get(interaction.guild.roles, id=role)
+            await interaction.user.add_roles(role)
         await log_to_channel(interaction.client.get_channel(config.REG_LOG_CHANNEL_ID), interaction)
         await interaction.response.send_message(
             f"Thank you {self.name.value}, you are now registered as {display_roles(interaction.user)}",  # noqa: E501


### PR DESCRIPTION
After playing for some time, I couldn't find a reason for this behavior. The roles are assigned correctly. I think, we'll need a bit more time to investigate this. I'm reverting for now.

<img width="444" alt="Screenshot 2023-07-12 at 00 04 10" src="https://github.com/EuroPython/discord/assets/44899477/37609d04-a000-4372-b919-343e14ca9302">


Reverts EuroPython/discord#48