### PR TITLE
Remove default values in registration interaction

### DIFF
--- a/EuroPythonBot/cogs/registration.py
+++ b/EuroPythonBot/cogs/registration.py
@@ -40,7 +40,6 @@ class RegistrationForm(discord.ui.Modal, title="Europython 2023 Registration"):
         min_length=4,
         max_length=6,
         placeholder="5-character combination of capital letters and numbers",
-        default="XXXXX",
     )
 
     name = discord.ui.TextInput(
@@ -50,7 +49,6 @@ class RegistrationForm(discord.ui.Modal, title="Europython 2023 Registration"):
         max_length=50,
         style=discord.TextStyle.short,
         placeholder="Your Full Name as printed on your ticket/badge",
-        default="My Full Name",
     )
 
     async def on_submit(self, interaction: discord.Interaction) -> None:


### PR DESCRIPTION
A lot of the errors in the registration log are that people press enter or confirm the dialog without replacing the default values with their actual values. By removing the default values, the text inputs will show the placeholder values, with handy help texts, and the interaction dialog will indicate that the fields are required if people press confirm without entering a value. This hopefully prevents a lot of these errors.