### PR TITLE
Add user id to registration logs

### DIFF
--- a/EuroPythonBot/helpers/channel_logging.py
+++ b/EuroPythonBot/helpers/channel_logging.py
@@ -5,9 +5,11 @@ async def log_to_channel(channel, interaction, name="", order="", roles=tuple(),
     else:
         user_name = user.nick
 
+    user_identifier = f"{user_name} ({user.id})"
     if error is None:
-        content = f"✅ : **`{user_name}` REGISTERED**\n{name=} {order=} {roles=}\n"
+        content = f"✅ : **`{user_identifier}` REGISTERED**\n{name=} {order=} {roles=}\n"
     else:
-        content = f"❌ : **`{user_name}` encounter an ERROR**\n{error.__class__.__name__}: {error}\n"
+        error_name = error.__class__.__name__
+        content = f"❌ : **`{user_identifier}` encounter an ERROR**\n{error_name}: {error}\n"
 
     await channel.send(content=content)


### PR DESCRIPTION
By logging the user id, we create a relationship between a Discord account and a registration using an immutable reference. The other references that we log, username and nickname, are both editable by the user.

Having an immutable relationship is important for situations in which we need to be able to determine identity, like Code of Conduct enforcement.