### PR TITLE
Registration updates

### DIFF
--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -33,20 +33,20 @@ class RegistrationForm(discord.ui.Modal, title="Europython 2023 Registration"):
         self.parent_cog = parent_cog
 
     order_field = discord.ui.TextInput(
-        label="Order",
+        label="Order ID (As on your ticket)",
         required=True,
         min_length=5,
         max_length=5,
-        placeholder="5-character combination of capital letters and numbers",
+        placeholder="e.g. 'ABC12'",
     )
 
     name_field = discord.ui.TextInput(
-        label="Full Name",
+        label="Full Name (As on your ticket)",
         required=True,
         min_length=3,
         max_length=50,
         style=discord.TextStyle.short,
-        placeholder="Your Full Name as printed on your ticket/badge",
+        placeholder="e.g. 'Jane Doe'",
     )
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
@@ -145,6 +145,7 @@ class RegistrationCog(commands.Cog):
 
     @commands.Cog.listener()
     async def on_ready(self):
+        print("HERE!!")
         reg_channel = self.bot.get_channel(config.REG_CHANNEL_ID)
 
         await reg_channel.purge()

--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -150,8 +150,10 @@ class RegistrationCog(commands.Cog):
         await reg_channel.purge()
         await self.pretix_connector.fetch_pretix_data()
 
-        title = "Welcome to EuroPython 2023 on Discord! 🎉🐍"
-        description = (
+        view = discord.ui.View(timeout=None)  # timeout=None to make it persistent
+        view.add_item(RegistrationButton(parent_cog=self))
+
+        welcome_message = create_welcome_message(
             "Follow these steps to complete your registration:\n\n"
             '1️⃣ Click on the green "Register Here 👈" button.\n\n'
             '2️⃣ Fill in the "Order" (found by clicking the order URL in your confirmation '
@@ -164,13 +166,7 @@ class RegistrationCog(commands.Cog):
             "See you on the server! 🐍💻🎉"
         )
 
-        view = discord.ui.View(timeout=None)  # timeout=None to make it persistent
-        view.add_item(RegistrationButton(parent_cog=self))
-
-        orange = 0xFF8331
-        embed = discord.Embed(title=title, description=description, color=orange)
-
-        await reg_channel.send(embed=embed, view=view)
+        await reg_channel.send(embed=welcome_message, view=view)
 
     async def cog_load(self) -> None:
         """Load the initial schedule."""
@@ -179,8 +175,18 @@ class RegistrationCog(commands.Cog):
 
     async def cog_unload(self) -> None:
         """Load the initial schedule."""
-        _logger.info("Scheduling periodic pretix update task.")
+        _logger.info("Canceling periodic pretix update task.")
         self.fetch_pretix_updates.cancel()
+
+        _logger.info("Replacing registration form with 'currently offline' message")
+        reg_channel = self.bot.get_channel(config.REG_CHANNEL_ID)
+        await reg_channel.purge()
+        await reg_channel.send(
+            embed=create_welcome_message(
+                "The registration bot is currently offline."
+                "We are sorry for the inconvenience and are working hard on fixing the issue."
+            )
+        )
 
     @tasks.loop(minutes=5)
     async def fetch_pretix_updates(self):
@@ -190,3 +196,12 @@ class RegistrationCog(commands.Cog):
             _logger.info("Finished the periodic pretix update.")
         except Exception:
             _logger.exception("Periodic pretix update failed")
+
+
+def create_welcome_message(body: str) -> discord.Embed:
+    orange = 0xFF8331
+    return discord.Embed(
+        title="Welcome to EuroPython 2024 on Discord! 🎉🐍",
+        description=body,
+        color=orange,
+    )

--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -184,7 +184,7 @@ class RegistrationCog(commands.Cog):
         await reg_channel.purge()
         await reg_channel.send(
             embed=create_welcome_message(
-                "The registration bot is currently offline."
+                "The registration bot is currently offline. "
                 "We are sorry for the inconvenience and are working hard on fixing the issue."
             )
         )

--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -35,8 +35,8 @@ class RegistrationForm(discord.ui.Modal, title="Europython 2023 Registration"):
     order_field = discord.ui.TextInput(
         label="Order",
         required=True,
-        min_length=4,
-        max_length=6,
+        min_length=5,
+        max_length=5,
         placeholder="5-character combination of capital letters and numbers",
     )
 

--- a/EuroPythonBot/registration/pretix_connector.py
+++ b/EuroPythonBot/registration/pretix_connector.py
@@ -93,7 +93,7 @@ class PretixConnector:
                 if next_url != url:
                     params = None
 
-                async with session.get(next_url, params=params) as response:
+                async with session.get(next_url, params=params, timeout=5) as response:
                     response.raise_for_status()
                     data = await response.json()
 

--- a/EuroPythonBot/registration/ticket.py
+++ b/EuroPythonBot/registration/ticket.py
@@ -13,7 +13,7 @@ def generate_ticket_key(*, order: str, name: str) -> str:
     name = "".join(c for c in name if not c.isspace())
     name = "".join(c for c in name if c not in string.punctuation)
 
-    return f"{order}-{name}"
+    return f"{order.upper()}-{name}"
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
- Close #17: Require order ID of exactly 5 characters, convert to uppercase for ticket lookups
- Close #15: Add timeout of 5 seconds for Pretix API requests
- Registration form: Improve label and placeholder to be more explicit (see screenshots)
- On bot shutdown: Replace registration form with message "currently offline" (see screenshots)

Bot online (unchanged):
![image](https://github.com/EuroPython/discord/assets/49114330/af6da99d-ae16-44cd-beb2-d00c3c09b575)

Registration form
![image](https://github.com/EuroPython/discord/assets/49114330/b1e7b18a-abd8-479b-96ce-aa4022616aad)

Bot offline: 
![image](https://github.com/EuroPython/discord/assets/49114330/d39cd012-2840-4cd0-9908-7dae4afb9ad2)