### PR TITLE
Replace 'EuroPython 2023' by 'EuroPython'

### DIFF
--- a/EuroPythonBot/extensions/__init__.py
+++ b/EuroPythonBot/extensions/__init__.py
@@ -1,1 +1,1 @@
-"""Extensions for the EuroPython 2023 Discord bot."""
+"""Extensions for the EuroPython Discord bot."""

--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -27,7 +27,7 @@ class RegistrationButton(discord.ui.Button["Registration"]):
         await interaction.response.send_modal(RegistrationForm(parent_cog=self.parent_cog))
 
 
-class RegistrationForm(discord.ui.Modal, title="Europython 2023 Registration"):
+class RegistrationForm(discord.ui.Modal, title="Europython Registration"):
     def __init__(self, parent_cog: RegistrationCog):
         super().__init__()
         self.parent_cog = parent_cog

--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -27,7 +27,7 @@ class RegistrationButton(discord.ui.Button["Registration"]):
         await interaction.response.send_modal(RegistrationForm(parent_cog=self.parent_cog))
 
 
-class RegistrationForm(discord.ui.Modal, title="Europython Registration"):
+class RegistrationForm(discord.ui.Modal, title="EuroPython 2024 Registration"):
     def __init__(self, parent_cog: RegistrationCog):
         super().__init__()
         self.parent_cog = parent_cog

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Europython 2023 Discord Bot
+# Europython Discord Bot
 
 An easy to deploy conference bot that manages roles for attendees via registration, notifies about upcoming sessions.
 Exposes Discord server statistics to organizers.

--- a/tests/programme_notifications/domain/test_create_discord_embed_for_session.py
+++ b/tests/programme_notifications/domain/test_create_discord_embed_for_session.py
@@ -6,7 +6,7 @@ be combined to create Discord embed.
 
 As we're sending embeds to webhooks in other Discord communities, the
 Discord channel information is optional: Members of other communities
-do not have access to the room channel in the EuroPython 2023 server.
+do not have access to the room channel in the EuroPython server.
 """
 
 import arrow


### PR DESCRIPTION
Fixes #123 