### PR TITLE
Update ansible playbook

### DIFF
--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -1,8 +1,8 @@
 ---
 - name: Deploy Discord Bot to the server
-  hosts: bot_server
+  hosts: discord2024
   vars:
-    repository_url: git@github.com:EuroPython/discord.git
+    repository_url: https://github.com/EuroPython/discord.git
 
   tasks:
 
@@ -60,7 +60,11 @@
         accept_hostkey: yes
         single_branch: yes
         version: main
-        key_file: /root/.ssh/deploy_key
+
+    - name: Ensure 'bot' group exists
+      group:
+        name: bot
+        gid: 1000
 
     - name: Create 'bot' user
       user:

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy Discord Bot to the server
-  hosts: discord2024
+  hosts: bot_server
   vars:
     repository_url: https://github.com/EuroPython/discord.git
 

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,2 +1,2 @@
-[bot_server]
-bot_server ansible_host=157.90.236.158
+[discord2024]
+discord2024 ansible_host=159.69.110.80

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,2 +1,2 @@
-[discord2024]
-discord2024 ansible_host=159.69.110.80
+[bot_server]
+bot_server ansible_host=159.69.110.80


### PR DESCRIPTION
- Update server IP address
- Since the repo is public, we don't need ssh cloning. Use https instead.
- When I first tried, it threw an error about group 1000 not existing. Added this step to ensure it exists.
- The renaming was not necessary, just wanted to match the actual server host name