### PR TITLE
Accept ticket IDs as order IDs

### DIFF
--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -33,20 +33,20 @@ class RegistrationForm(discord.ui.Modal, title="EuroPython 2024 Registration"):
         self.parent_cog = parent_cog
 
     order_field = discord.ui.TextInput(
-        label="Order ID",
+        label="Order ID (As printed on your badge or ticket)",
         required=True,
         min_length=5,
-        max_length=5,
-        placeholder="123AB",
+        max_length=10,
+        placeholder="Like '#123AB-1' or '123AB'",
     )
 
     name_field = discord.ui.TextInput(
-        label="Full Name (As printed on your badge)",
+        label="Name (As printed on your badge or ticket)",
         required=True,
         min_length=1,
         max_length=50,
         style=discord.TextStyle.short,
-        placeholder="Jane Doe",
+        placeholder="Like 'Jane Doe'",
     )
 
     async def on_submit(self, interaction: discord.Interaction) -> None:

--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -36,7 +36,7 @@ class RegistrationForm(discord.ui.Modal, title="EuroPython 2024 Registration"):
         label="Order ID (As printed on your badge or ticket)",
         required=True,
         min_length=5,
-        max_length=10,
+        max_length=9,
         placeholder="Like '#123AB-1' or '123AB'",
     )
 

--- a/EuroPythonBot/registration/pretix_connector.py
+++ b/EuroPythonBot/registration/pretix_connector.py
@@ -69,6 +69,7 @@ class PretixConnector:
 
     async def _fetch_pretix_items(self) -> None:
         """Fetch all items from the Pretix API."""
+        _logger.info("Fetching all pretix items")
         items_as_json = await self._fetch_all_pages(f"{self._pretix_api_url}/items")
 
         for item_as_json in items_as_json:

--- a/EuroPythonBot/registration/pretix_connector.py
+++ b/EuroPythonBot/registration/pretix_connector.py
@@ -108,8 +108,15 @@ class PretixConnector:
 
     def get_ticket(self, *, order: str, name: str) -> Ticket | None:
         """Get the ticket for a given order ID and name, or None if none was found."""
+        _logger.debug("Lookup for order '%s' and name '%s'", order, name)
+
+        # convert ticket ID to order ID ('#ABC01-1' -> 'ABC01')
+        order = order.upper()
+        order = order.lstrip("#")
+        order = order.split("-")[0]
+
         # try different name orders (e.g. family name first vs last)
-        # limit number of possible permutations to test to prevent abuse
+        # prevent abuse by limiting the number of possible permutations to test
         max_name_components = 5
         name_parts = name.split(maxsplit=max_name_components - 1)
         for permutation in itertools.permutations(name_parts):

--- a/EuroPythonBot/registration/pretix_connector.py
+++ b/EuroPythonBot/registration/pretix_connector.py
@@ -112,9 +112,9 @@ class PretixConnector:
         _logger.debug("Lookup for order '%s' and name '%s'", order, name)
 
         # convert ticket ID to order ID ('#ABC01-1' -> 'ABC01')
-        order = order.upper()
         order = order.lstrip("#")
         order = order.split("-")[0]
+        order = order.upper()
 
         # try different name orders (e.g. family name first vs last)
         # prevent abuse by limiting the number of possible permutations to test

--- a/tests/registration/test_pretix_connector.py
+++ b/tests/registration/test_pretix_connector.py
@@ -116,6 +116,16 @@ async def test_get_ticket(pretix_mock):
     assert ticket == Ticket(order="BR7UH", name="Eva Nováková", type="Business")
 
 
+async def test_get_ticket_handles_ticket_ids(pretix_mock):
+    pretix_connector = PretixConnector(url=pretix_mock.base_url, token=PRETIX_API_TOKEN)
+
+    await pretix_connector.fetch_pretix_data()
+
+    ticket = pretix_connector.get_ticket(order="#BR7UH-3", name="Eva Nováková")
+
+    assert ticket == Ticket(order="BR7UH", name="Eva Nováková", type="Business")
+
+
 async def test_get_ticket_ignores_accents(pretix_mock):
     pretix_connector = PretixConnector(url=pretix_mock.base_url, token=PRETIX_API_TOKEN)
 


### PR DESCRIPTION
Currently, users have to enter their Pretix order ID to register (e.g. `ABC01`). The conference badges contain the individual ticket ID (e.g. `#ABC01-1`).

With this PR, the order ID is extracted from the ticket ID so users can enter what's printed on their badge.

![image](https://github.com/EuroPython/discord/assets/49114330/7747751d-c980-4566-8022-787bddb4651c)

Closes #119 