### PR TITLE
152 remove cancelled tickets during pretix updates

### DIFF
--- a/tests/registration/test_pretix_connector.py
+++ b/tests/registration/test_pretix_connector.py
@@ -180,11 +180,7 @@ async def test_positions_without_name_are_ignored(aiohttp_client, unused_tcp_por
                             "code": "ABC01",
                             "status": "p",
                             "positions": [
-                                {
-                                    "order": "ABC01",
-                                    "item": 339041,
-                                    "attendee_name": None,
-                                }
+                                {"order": "ABC01", "item": 339041, "attendee_name": None}
                             ],
                         }
                     ],

--- a/tests/registration/test_pretix_connector.py
+++ b/tests/registration/test_pretix_connector.py
@@ -287,7 +287,7 @@ async def test_consecutive_fetches_after_some_time_fetch_updates(pretix_mock):
     assert requests[0].url.path == "/items"
     assert requests[1].url.path == "/orders"
 
-    # third fetch after >2 minutes should fetch updates
+    # fetch after >2 minutes should fetch updates
     three_minutes_before = initial_time - timedelta(minutes=3)
     pretix_connector._last_fetch = three_minutes_before
 


### PR DESCRIPTION
Closes #152 

When a previously paid order is not paid anymore (i.e. cancelled), remove the ticket reference so registration is no longer possible.