### PR TITLE
Handle dates without sessions gracefully

### DIFF
--- a/EuroPythonBot/program_notifications/program_connector.py
+++ b/EuroPythonBot/program_notifications/program_connector.py
@@ -103,7 +103,16 @@ class ProgramConnector:
     async def get_sessions_by_date(self, date_now: date) -> list[Session]:
         if self.sessions_by_day is None:
             await self.fetch_schedule()
-        return self.sessions_by_day[date_now]
+
+        try:
+            sessions_on_day = self.sessions_by_day[date_now]
+        except KeyError:
+            # debug to keep the logs clean,
+            # because this is expected on non-conference days
+            _logger.debug(f"No sessions found on {date_now}")
+            sessions_on_day = []
+
+        return sessions_on_day
 
     async def get_upcoming_sessions_for_room(self, room: str) -> list[Session]:
         # upcoming sessions are those that start in 5 minutes or less

--- a/tests/program_notifications/test_program_connector.py
+++ b/tests/program_notifications/test_program_connector.py
@@ -103,5 +103,5 @@ async def test_get_sessions_by_date_key_error(tmp_path):
     )
     await connector.fetch_schedule()
     test_date = date(2024, 7, 13)  # Use a date not in the available schedule
-    with pytest.raises(KeyError):
-        await connector.get_sessions_by_date(test_date)
+    sessions = await connector.get_sessions_by_date(test_date)
+    assert sessions == []


### PR DESCRIPTION
I was going to open this PR after ``program-notifications`` got merged, however, without this it fails.

Basically, if the if the passed date is not a key in the sessions_by_day dictionary, it logs a warning and returns an empty list.