### PR TITLE
Cache pretix data locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ __pycache__
 .DS_Store
 registered_log.txt
 schedule.json
+pretix_cache.json

--- a/EuroPythonBot/config.toml
+++ b/EuroPythonBot/config.toml
@@ -37,6 +37,7 @@ REGISTERED_LOG_FILE = "registered_log.txt"
 
 [pretix]
 PRETIX_BASE_URL = "https://pretix.eu/api/v1/organizers/europython/events/ep2024"
+PRETIX_CACHE_FILE = "pretix_cache.json"
 
 [logging]
 LOG_LEVEL = "INFO"

--- a/EuroPythonBot/configuration.py
+++ b/EuroPythonBot/configuration.py
@@ -41,6 +41,7 @@ class Config(metaclass=Singleton):
 
             # Pretix
             self.PRETIX_BASE_URL = config["pretix"]["PRETIX_BASE_URL"]
+            self.PRETIX_CACHE_FILE = Path(config["pretix"]["PRETIX_CACHE_FILE"])
 
             role_name_to_id: dict[str, int] = config["roles"]
             self.ITEM_TO_ROLES: dict[str, list[int]] = self._translate_role_names_to_ids(

--- a/EuroPythonBot/registration/cog.py
+++ b/EuroPythonBot/registration/cog.py
@@ -156,7 +156,9 @@ class RegistrationCog(commands.Cog):
         self.bot = bot
 
         self.pretix_connector = PretixConnector(
-            url=config.PRETIX_BASE_URL, token=os.environ["PRETIX_TOKEN"]
+            url=config.PRETIX_BASE_URL,
+            token=os.environ["PRETIX_TOKEN"],
+            cache_file=config.PRETIX_CACHE_FILE,
         )
         self.registration_logger = RegistrationLogger(config.REGISTERED_LOG_FILE)
         _logger.info("Cog 'Registration' has been initialized")

--- a/EuroPythonBot/registration/ticket.py
+++ b/EuroPythonBot/registration/ticket.py
@@ -1,6 +1,6 @@
 import string
-from dataclasses import dataclass
 
+from pydantic import BaseModel, ConfigDict, computed_field
 from unidecode import unidecode
 
 
@@ -16,13 +16,14 @@ def generate_ticket_key(*, order: str, name: str) -> str:
     return f"{order}-{name}"
 
 
-@dataclass(frozen=True)
-class Ticket:
+class Ticket(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
     order: str
     name: str
     type: str
     variation: str | None
 
-    @property
+    @computed_field
     def key(self) -> str:
         return generate_ticket_key(order=self.order, name=self.name)

--- a/EuroPythonBot/staging-config.toml
+++ b/EuroPythonBot/staging-config.toml
@@ -34,6 +34,7 @@ REGISTERED_LOG_FILE = "registered_log.txt"
 
 [pretix]
 PRETIX_BASE_URL = "https://pretix.eu/api/v1/organizers/europython/events/ep2023-staging2"
+PRETIX_CACHE_FILE = "pretix_cache.json"
 
 [logging]
 LOG_LEVEL = "INFO"

--- a/EuroPythonBot/staging-config.toml
+++ b/EuroPythonBot/staging-config.toml
@@ -44,6 +44,7 @@ LOG_LEVEL = "INFO"
 timezone_offset = 2
 api_url = "https://programapi24.europython.eu/2024/schedule.json"
 schedule_cache_file = "schedule.json"
+livestream_url_file = "livestreams.toml"
 
 # optional simulated start time for testing program notifications
 # simulated_start_time = "2024-07-10T07:30:00"

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -87,7 +87,7 @@
         owner: bot
         group: bot
 
-    - name: Create livestreams.toml in bot's home directory
+    - name: Create pretix_cache.json in bot's home directory
       file:
         path: /home/bot/pretix_cache.json
         state: touch

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -87,6 +87,13 @@
         owner: bot
         group: bot
 
+    - name: Create livestreams.toml in bot's home directory
+      file:
+        path: /home/bot/pretix_cache.json
+        state: touch
+        owner: bot
+        group: bot
+
     - name: Create schedule.json in bot's home directory
       file:
         path: /home/bot/schedule.json

--- a/compose.yaml
+++ b/compose.yaml
@@ -23,6 +23,11 @@ services:
         target: /home/bot/schedule.json
         read_only: false
 
+      - type: bind
+        source: /home/bot/pretix_cache.json
+        target: /home/bot/pretix_cache.json
+        read_only: false
+
     # read all container only logs with
     # journalctl -u docker IMAGE_NAME=europythonbot -f
     logging:

--- a/tests/registration/test_registration_logger.py
+++ b/tests/registration/test_registration_logger.py
@@ -9,7 +9,9 @@ from registration.ticket import Ticket
 def test_with_empty_file(tmp_path: Path) -> None:
     logger = RegistrationLogger(tmp_path / "registrations.txt")
 
-    assert not logger.is_registered(Ticket("ABC01", "John Doe", "Business", "Tutorials"))
+    assert not logger.is_registered(
+        Ticket(order="ABC01", name="John Doe", type="Business", variation="Tutorials")
+    )
 
 
 def test_with_existing_file(tmp_path: Path) -> None:
@@ -17,14 +19,16 @@ def test_with_existing_file(tmp_path: Path) -> None:
 
     logger = RegistrationLogger(tmp_path / "registrations.txt")
 
-    assert logger.is_registered(Ticket("ABC01", "John Doe", "Business", "Tutorials"))
+    assert logger.is_registered(
+        Ticket(order="ABC01", name="John Doe", type="Business", variation="Tutorials")
+    )
 
 
 @pytest.mark.asyncio
 async def test_register_ticket_on_empty_log(tmp_path: Path) -> None:
     logger = RegistrationLogger(tmp_path / "registrations.txt")
 
-    ticket = Ticket("ABC01", "John Doe", "Business", "Tutorials")
+    ticket = Ticket(order="ABC01", name="John Doe", type="Business", variation="Tutorials")
 
     await logger.mark_as_registered(ticket)
 
@@ -36,7 +40,7 @@ async def test_register_ticket_on_empty_log(tmp_path: Path) -> None:
 async def test_register_ticket_with_existing_file(tmp_path: Path) -> None:
     logger = RegistrationLogger(tmp_path / "registrations.txt")
 
-    ticket = Ticket("ABC01", "John Doe", "Business", "Tutorials")
+    ticket = Ticket(order="ABC01", name="John Doe", type="Business", variation="Tutorials")
 
     await logger.mark_as_registered(ticket)
 
@@ -50,7 +54,7 @@ async def test_register_ticket_with_existing_log(tmp_path: Path) -> None:
 
     logger = RegistrationLogger(tmp_path / "registrations.txt")
 
-    ticket = Ticket("ABC02", "Jane Doe", "Business", "Tutorials")
+    ticket = Ticket(order="ABC02", name="Jane Doe", type="Business", variation="Tutorials")
 
     await logger.mark_as_registered(ticket)
 
@@ -62,7 +66,7 @@ async def test_register_ticket_with_existing_log(tmp_path: Path) -> None:
 async def test_register_already_registered_ticket(tmp_path: Path) -> None:
     logger = RegistrationLogger(tmp_path / "registrations.txt")
 
-    ticket = Ticket("ABC02", "Jane Doe", "Business", "Tutorials")
+    ticket = Ticket(order="ABC02", name="Jane Doe", type="Business", variation="Tutorials")
 
     await logger.mark_as_registered(ticket)
 


### PR DESCRIPTION
Currently, pretix data is fetched regularly and kept in memory. When the bot is restarted, all pretix data has to be fetched again, so if we restart the bot while pretix is offline, no registrations are possible.

The PR adds caching of Pretix data in a local file, which is used when the bot is starting up.

Implementation: On each successful pretix data fetch, all in-memory pretix data is written to the persistent file `pretix_cache.json`. On bot startup, the content of this file is used as initial state before the first successful pretix fetch occurred.

Details:
- Change type of class `Ticket` from `dataclasses.dataclass` to `pydantic.BaseModel` to simplify JSON de-/serialization.
- Add config value `pretix.PRETIX_CACHE_FILE`
- Add file `pretix_cache.json` to .gitignore, ansible playbook, docker-compose
