### PR TITLE
Move discord server host to GitHub secret

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,6 @@ jobs:
           ssh-private-key: ${{ secrets.DISCORD_BOT_DEPLOY_KEY }}
 
       - name: Deploy EuroPythonBot with ansible
-        run: ansible-playbook -i ansible/inventory.ini ansible/deploy-playbook.yml --private-key="/home/runner/.ssh/id_rsa" --user=root
+        run: ansible-playbook -i ${{ secrets.DISCORD_BOT_SERVER_HOST }}, ansible/deploy-playbook.yml --private-key="/home/runner/.ssh/id_rsa" --user=root
         env:
           ANSIBLE_HOST_KEY_CHECKING: "false"

--- a/ansible/deploy-playbook.yml
+++ b/ansible/deploy-playbook.yml
@@ -1,6 +1,6 @@
 ---
 - name: Deploy Discord Bot to the server
-  hosts: bot_server
+  hosts: all
   vars:
     repository_url: https://github.com/EuroPython/discord.git
 

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,2 +1,0 @@
-[bot_server]
-bot_server ansible_host=188.245.198.145


### PR DESCRIPTION
Fixes #171 

Goal: Don't store server hostname/IP in the repository.

Steps:
* Remove ansible inventory file
* Configure ansible playbook to run on all available hosts
* Run `ansible-playbook` with the server host as inline parameter
* Store server host in Github Secret `DISCORD_BOT_SERVER_HOST`