### PR TITLE
Add 'Remote Attendees' channels

### DIFF
--- a/scripts/configure-guild.py
+++ b/scripts/configure-guild.py
@@ -234,7 +234,13 @@ SERVER_CONFIG = GuildConfig(
             color=DARK_ORANGE,
             hoist=True,
             mentionable=True,
-            permissions=["kick_members", "ban_members"],
+            permissions=[
+                "kick_members",
+                "ban_members",
+                "priority_speaker",
+                "deafen_members",
+                "mute_members",
+            ],
         ),
         Role(
             name=ROLE_MODERATORS,
@@ -246,6 +252,9 @@ SERVER_CONFIG = GuildConfig(
                 "moderate_members",
                 "manage_messages",
                 "manage_threads",
+                "priority_speaker",
+                "deafen_members",
+                "mute_members",
             ],
         ),
         Role(
@@ -295,6 +304,9 @@ SERVER_CONFIG = GuildConfig(
                 "add_reactions",
                 "read_message_history",
                 "use_application_commands",
+                "connect",
+                "speak",
+                "use_voice_activation",
             ],
         ),
     ],
@@ -521,6 +533,17 @@ SERVER_CONFIG = GuildConfig(
                         ),
                     ],
                 ),
+            ],
+            permission_overwrites=[
+                PermissionOverwrite(roles=[ROLE_EVERYONE], deny=["view_channel"]),
+                PermissionOverwrite(roles=ROLES_REGISTERED, allow=["view_channel"]),
+            ],
+        ),
+        Category(
+            name="Remote Attendees",
+            channels=[
+                TextChannel(name="remote-text", topic="Text chat for remote attendees"),
+                VoiceChannel(name="remote-voice"),
             ],
             permission_overwrites=[
                 PermissionOverwrite(roles=[ROLE_EVERYONE], deny=["view_channel"]),

--- a/scripts/configure-guild.py
+++ b/scripts/configure-guild.py
@@ -10,7 +10,7 @@ import re
 import sys
 import textwrap
 from collections import defaultdict
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 import discord
 from discord import VerificationLevel
@@ -170,7 +170,7 @@ class GuildConfig(BaseModel):
 
     @model_validator(mode="after")
     def verify_system_channel_names(self) -> Self:
-        channel_names = []
+        channel_names: list[str] = []
         for category in self.categories:
             channel_names.extend(channel.name for channel in category.channels)
 
@@ -1122,7 +1122,7 @@ class GuildConfigurator:
             await self.guild.edit(verification_level=discord.VerificationLevel.medium)
 
         if self.guild.default_notifications != discord.NotificationLevel.only_mentions:
-            self.guild.edit(default_notifications=discord.NotificationLevel.only_mentions)
+            await self.guild.edit(default_notifications=discord.NotificationLevel.only_mentions)
 
         if "COMMUNITY" not in self.guild.features:
             logger.debug("Enable guild 'COMMUNITY' feature")
@@ -1151,7 +1151,7 @@ class GuildConfigurationBot(Bot):
 
         await self.close()
 
-    async def on_error(self, event: str, /, *args, **kwargs) -> None:  # noqa: ANN002,ANN003 (types)
+    async def on_error(self, event: str, /, *args: Any, **kwargs: Any) -> None:  # noqa: ANN401 (Any)
         """Event handler for uncaught exceptions."""
         exc_type, exc_value, _exc_traceback = sys.exc_info()
         if exc_type is None:


### PR DESCRIPTION
Fixes #211 

General:
* scripts/configure-guild.py now supports creation and management of voice channels

Specific:
* Add new category 'Remote Attendees' between 'Rooms' and 'Conference Organization'
* Add text channel 'remote-text' and voice channel 'remote-voice'
* These channels are accessible to all registered attendees
* Moderators and CoC can deafen and mute members, and can use the [Priority Speaker](https://support.discord.com/hc/en-us/articles/360011876531-Setting-up-Priority-Speaker) mode
* Streaming and soundboards are not permitted

Screenshot:
![image](https://github.com/user-attachments/assets/a2f2c851-8072-4964-9c7c-9ecc96547e55)