### PR TITLE
Refer to canonical CoC contact information instead of individual users

### DIFF
--- a/scripts/configure-guild.py
+++ b/scripts/configure-guild.py
@@ -370,26 +370,10 @@ SERVER_CONFIG = GuildConfig(
                         """,  # noqa: E501 (line too long)
                         """
                         ## General Reporting Procedure
-                        If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the Code of Conduct committee immediately. They can be reached by emailing **coc@europython.eu**.
-
-                        If you prefer, you can also directly contact:
-
-                        - Person 1
-                          - Email: ...@europython.eu
-                          - Telegram: @...
-                          - Discord: <@...>
-                        - Person 2
-                          - Email: ...@europython.eu
-                          - Telegram: @...
-                          - Discord: <@...>
-                        - Person 3
-                          - Email: ...@europython.eu
-                          - Discord: <@...>
-                        - Person 4
-                          - Email: ...@europython.eu
-                          - Discord: <@...>
-
-                        Committee members have the role <<@&Code of Conduct Committee>> in this community.
+                        If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact a member of the Code of Conduct committee immediately:
+                        - Email: [coc@europython.eu](mailto:coc@europython.eu)
+                        - Discord role: <<@&Code of Conduct Committee>>
+                        - Individual contact information: [EPS Website](https://www.europython-society.org/coc/#contact-information)
                         """,  # noqa: E501 (line too long)
                         """
                         ## Links


### PR DESCRIPTION
## Before
![image](https://github.com/user-attachments/assets/bb876314-92ff-4528-96a8-c48aaeb75a9c)

## After
![image](https://github.com/user-attachments/assets/560bd391-5dd8-458e-a87f-67d77b0457ee)

(The link 'EPS Website' refers to https://www.europython-society.org/coc/#contact-information)

## Rejected ideas
* Include the personal information of current CoC members directly in the script (name, email, Discord user ID, Telegram user name).
    * Why not? Storing PII in a public git repository is scary (even with explicit consent)
* Store personal information of current CoC members in a config file, include it via a templating solution (e.g. using jinja2).
    * Why not? The additional complexity is not worth it.
* Create the messages in #code-of-conduct manually
    * Why not? The additional effort and complexity are not worth it.