### PR TITLE
Escape markdown in session notification title and description

### DIFF
--- a/src/europython_discord/program_notifications/session_to_embed.py
+++ b/src/europython_discord/program_notifications/session_to_embed.py
@@ -6,7 +6,7 @@ from enum import Enum
 from typing import Final
 
 from discord import Embed
-from discord.utils import format_dt
+from discord.utils import escape_markdown, format_dt
 
 from europython_discord.program_notifications.models import Session, Speaker
 
@@ -29,7 +29,7 @@ def create_session_embed(session: Session, livestream_url: str | None) -> Embed:
     :return: A Discord embed for this session
     """
     embed = Embed(
-        title=_format_title(session.title),
+        title=_format_title(escape_markdown(session.title)),
         description=_create_description(session),
         url=session.website_url,
         color=_get_color(session.level),
@@ -79,7 +79,7 @@ def _create_description(session: Session) -> str | None:
     """
     if not session.tweet:
         return None
-    tweet_short = textwrap.shorten(session.tweet, width=_TWEET_WIDTH)
+    tweet_short = textwrap.shorten(escape_markdown(session.tweet), width=_TWEET_WIDTH)
     return f"{tweet_short}\n\n[Read more about this session]({session.website_url})"
 
 

--- a/tests/program_notifications/test_session_to_embed.py
+++ b/tests/program_notifications/test_session_to_embed.py
@@ -68,6 +68,12 @@ def test_embed_title_long(session: Session) -> None:
     )
 
 
+def test_embed_title_with_markdown(session: Session) -> None:
+    session.title = "A talk about __slots__ and *things*."
+    embed = session_to_embed.create_session_embed(session, None)
+    assert embed.title == "A talk about \\_\\_slots\\_\\_ and \\*things\\*."
+
+
 def test_embed_description_short(session: Session) -> None:
     """Test the description (tweet) of the embed with a short description."""
     session.tweet = "Short tweet."
@@ -101,6 +107,15 @@ def test_embed_description_empty(session: Session) -> None:
     session.tweet = ""
     embed = session_to_embed.create_session_embed(session, None)
     assert embed.description is None
+
+
+def test_embed_description_with_markdown(session: Session) -> None:
+    session.tweet = "A talk about __slots__ and *things*."
+    embed = session_to_embed.create_session_embed(session, None)
+    assert embed.description == (
+        "A talk about \\_\\_slots\\_\\_ and \\*things\\*.\n\n"
+        f"[Read more about this session]({session.website_url})"
+    )
 
 
 def test_embed_url(session: Session) -> None:


### PR DESCRIPTION
Before:
<img width="529" height="285" alt="image" src="https://github.com/user-attachments/assets/839a30bb-0e48-457f-9b4b-4ec67132c117" />
<img width="529" height="287" alt="image" src="https://github.com/user-attachments/assets/2274c2ac-0b6e-401c-a984-2cd0fb3a4a99" />

After (livestream missing due to test setup):
<img width="526" height="289" alt="image" src="https://github.com/user-attachments/assets/50ceac08-7fa8-4825-94e6-55cb858547a3" />
<img width="528" height="285" alt="image" src="https://github.com/user-attachments/assets/de4d6370-0459-437f-bc13-49eb6672b309" />
