### PR TITLE
Update configurations for EP2026

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.12-slim
+FROM python:3.11.15-slim
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /bin/
 
 RUN groupadd --gid 1000 bot && \

--- a/prod-config.toml
+++ b/prod-config.toml
@@ -5,7 +5,7 @@ registration_form_channel_name = "registration-form"
 registration_help_channel_name = "registration-help"
 registration_log_channel_name = "registration-log"
 
-pretix_base_url = "https://pretix.eu/api/v1/organizers/europython/events/ep2025"
+pretix_base_url = "https://pretix.eu/api/v1/organizers/europython/events/ep2026"
 
 registered_cache_file = "registered_log.txt"
 pretix_cache_file = "pretix_cache.json"
@@ -37,7 +37,7 @@ pretix_cache_file = "pretix_cache.json"
 
 [program_notifications]
 # UTC offset in hours (e.g. 2 for CEST)
-api_url = "https://static.europython.eu/programme/ep2025/releases/current/schedule.json"
+api_url = "https://static.europython.eu/programme/ep2026/releases/current/schedule.json"
 schedule_cache_file = "schedule_cache.json"
 livestream_url_file = "livestreams.toml"
 main_notification_channel_name = "programme-notifications"
@@ -50,12 +50,11 @@ main_notification_channel_name = "programme-notifications"
 # fast_mode = true
 
 [program_notifications.rooms_to_channel_names]
-"Forum Hall" = "forum-hall"
-"South Hall 2A" = "south-hall-2a"
-"South Hall 2B" = "south-hall-2b"
-"North Hall" = "north-hall"
-"Terrace 2A" = "terrace-2a"
-"Terrace 2B" = "terrace-2b"
+"S1" = "s1"
+"S2" = "s2"
+"S3A" = "s3a"
+"S3B" = "s3b"
+"S4" = "s4"
 "Exhibit Hall" = "exhibit-hall"
 
 [guild_statistics]

--- a/scripts/configure-guild.py
+++ b/scripts/configure-guild.py
@@ -465,7 +465,7 @@ SERVER_CONFIG = GuildConfig(
             ],
         ),
         Category(
-            name="EuroPython 2025",
+            name="EuroPython 2026",
             channels=[
                 TextChannel(
                     name="announcements",
@@ -577,12 +577,11 @@ SERVER_CONFIG = GuildConfig(
                         PermissionOverwrite(roles=[ROLE_EVERYONE], deny=["send_messages"])
                     ],
                 ),
-                TextChannel(name="forum-hall", topic="Livestream: [TBA]"),
-                TextChannel(name="south-hall-2a", topic="Livestream: [TBA]"),
-                TextChannel(name="south-hall-2b", topic="Livestream: [TBA]"),
-                TextChannel(name="north-hall", topic="Livestream: [TBA]"),
-                TextChannel(name="terrace-2a", topic="Livestream: [TBA]"),
-                TextChannel(name="terrace-2b", topic="Livestream: [TBA]"),
+                TextChannel(name="s1", topic="Livestream: [TBA]"),
+                TextChannel(name="s2", topic="Livestream: [TBA]"),
+                TextChannel(name="s3a", topic="Livestream: [TBA]"),
+                TextChannel(name="s3b", topic="Livestream: [TBA]"),
+                TextChannel(name="s4", topic="Livestream: [TBA]"),
                 TextChannel(
                     name="exhibit-hall", topic="For conversations related to the exhibit hall."
                 ),
@@ -624,7 +623,7 @@ SERVER_CONFIG = GuildConfig(
                     name="beginners-day",
                     topic=(
                         "Channel for the Beginners' Day: "
-                        "https://ep2025.europython.eu/beginners-day/"
+                        "https://ep2026.europython.eu/beginners-day/"
                     ),
                     permission_overwrites=[
                         PermissionOverwrite(

--- a/src/europython_discord/registration/cog.py
+++ b/src/europython_discord/registration/cog.py
@@ -17,10 +17,10 @@ _logger = logging.getLogger(__name__)
 
 # Discord's colon-syntax `:point_left:` does not work in button labels, so we use `\N{...}` here
 REGISTRATION_BUTTON_LABEL = "Register here \N{WHITE LEFT POINTING BACKHAND INDEX}"
-WELCOME_MESSAGE_TITLE = "## Welcome to EuroPython 2025 on Discord! :tada::snake:"
+WELCOME_MESSAGE_TITLE = "## Welcome to EuroPython 2026 on Discord! :tada::snake:"
 
 
-class RegistrationForm(discord.ui.Modal, title="EuroPython 2025 Registration"):
+class RegistrationForm(discord.ui.Modal, title="EuroPython 2026 Registration"):
     def __init__(
         self,
         config: RegistrationConfig,
@@ -206,7 +206,7 @@ class RegistrationCog(commands.Cog):
             :two: Fill in your Order ID and the name on your ticket. You can find them
             * Printed on your ticket
             * Printed on your badge
-            * In the email "[EuroPython 2025] Your order: XXXXX" from support@pretix.eu
+            * In the email "[EuroPython 2026] Your order: XXXXX" from support@pretix.eu
 
             :three: Click "Submit".
 
@@ -216,7 +216,7 @@ class RegistrationCog(commands.Cog):
             * In the {reg_help_channel.mention} channel
             * By speaking to a volunteer in a yellow t-shirt
 
-            Enjoy our EuroPython 2025 Community Server! :snake::computer::tada:
+            Enjoy our EuroPython 2026 Community Server! :snake::computer::tada:
             """
         )
 

--- a/test-config.toml
+++ b/test-config.toml
@@ -37,25 +37,24 @@ pretix_cache_file = "pretix_cache.json"
 
 [program_notifications]
 # UTC offset in hours (e.g. 2 for CEST)
-api_url = "https://static.europython.eu/programme/ep2025/releases/current/schedule.json"
+api_url = "https://static.europython.eu/programme/ep2026/releases/current/schedule.json"
 schedule_cache_file = "schedule_cache.json"
 livestream_url_file = "test-livestreams.toml"
 main_notification_channel_name = "programme-notifications"
 
 # optional simulated start time for testing program notifications
-simulated_start_time = "2025-07-14T09:15:00+02:00"
+simulated_start_time = "2026-07-13T09:15:00+02:00"
 
 # optional fast mode for faster testing of program notifications
 # will only take effect if simulated_start_time is set
 fast_mode = true
 
 [program_notifications.rooms_to_channel_names]
-"Forum Hall" = "forum-hall"
-"South Hall 2A" = "south-hall-2a"
-"South Hall 2B" = "south-hall-2b"
-"North Hall" = "north-hall"
-"Terrace 2A" = "terrace-2a"
-"Terrace 2B" = "terrace-2b"
+"S1" = "s1"
+"S2" = "s2"
+"S3A" = "s3a"
+"S3B" = "s3b"
+"S4" = "s4"
 "Exhibit Hall" = "exhibit-hall"
 
 [guild_statistics]


### PR DESCRIPTION
Updated room names, some dates, general 2025 -> 2026 renames.
Also, changed Python version from `3.11.12` to the latest security/bug-fix release of `3.11`, which is `3.11.15`.