### PR TITLE
Fix "something went wrong" during registration

### DIFF
--- a/src/europython_discord/registration/cog.py
+++ b/src/europython_discord/registration/cog.py
@@ -55,6 +55,7 @@ class RegistrationForm(discord.ui.Modal, title="EuroPython 2026 Registration"):
         order = self.order_field.value
 
         _logger.info(f"Registration attempt: {order=}, {name=}")
+        await interaction.response.defer(ephemeral=True, thinking=True)
         tickets = self.pretix_connector.get_tickets(order=order, name=name)
 
         if not tickets:
@@ -108,6 +109,11 @@ class RegistrationForm(discord.ui.Modal, title="EuroPython 2026 Registration"):
         await self.log_registration_to_channel(interaction, name=name, order=order, roles=roles)
         await self.registration_logger.mark_as_registered(tickets[0])
         _logger.info(f"Registration successful: {order=}, {name=}")
+        await interaction.edit_original_response(
+            content=(
+                "You are now registered!\n\nYour nickname was changed to the name on your ticket."
+            )
+        )
 
     async def on_error(self, interaction: Interaction, error: Exception) -> None:
         user_is_admin = any(role.name == "Admin" for role in interaction.user.roles)
@@ -140,10 +146,10 @@ class RegistrationForm(discord.ui.Modal, title="EuroPython 2026 Registration"):
         reg_help_channel = discord_get(
             interaction.guild.channels, name=self.config.registration_help_channel_name
         )
-        await interaction.response.send_message(
-            f"{message} If you need help, please contact us in {reg_help_channel.mention}.",
-            ephemeral=True,
-            delete_after=None,
+        await interaction.edit_original_response(
+            content=(
+                f"{message} If you need help, please contact us in {reg_help_channel.mention}."
+            )
         )
 
     async def log_error_to_channel(self, interaction: Interaction, message: str) -> None:


### PR DESCRIPTION
Most likely this is the reason [discord](https://docs.discord.com/developers/interactions/receiving-and-responding#:~:text=Interaction%20tokens%20are%20valid%20for%2015%20minutes%20and%20can%20be%20used%20to%20send%20followup%20messages%20but%20you%20must%20send%20an%20initial%20response%20within%203%20seconds%20of%20receiving%20the%20event.%20If%20the%203%20second%20deadline%20is%20exceeded%2C%20the%20token%20will%20be%20invalidated.)

When I simply added `time.sleep` at the end of the `on_submit` method, I was able to reproduce issue locally.

``` python
async def on_submit(self, interaction: discord.Interaction) -> None:
    .....
    await self.log_registration_to_channel(interaction, name=name, order=order, roles=roles)
    await self.registration_logger.mark_as_registered(tickets[0])
    _logger.info(f"Registration successful: {order=}, {name=}")
    time.sleep(2.5)
```

The fix is to respond to an interaction asap and after successful registration, replace the message.


After submitting a form:

<img width="1664" height="122" alt="image" src="https://github.com/user-attachments/assets/6af65f3a-42a7-4a50-8c07-befe8030feca" />

Then, in case of error it becomes:

<img width="1233" height="287" alt="image" src="https://github.com/user-attachments/assets/3913ae33-5b66-487e-a464-8201a0370521" />

And on success:

<img width="1233" height="287" alt="image" src="https://github.com/user-attachments/assets/3f2d3201-3fa1-43a5-b405-d59031d0fcaf" />


